### PR TITLE
Adding an enum and making the recording types to filter out of consideration more restrictive

### DIFF
--- a/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperValidRecordingEntryTestCases.cs
+++ b/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperValidRecordingEntryTestCases.cs
@@ -53,13 +53,13 @@ namespace WMCDuplicateRemover.Tests.Wrappers
 
             yield return new TestCaseData(new EventLogEntryWrapper("Recording of Parks and Recreation: The Pawnee-Eagleton Tip off Classic began as scheduled on 5/11/2015 10:57:34 AM while the program was already in progress.",
                 WMC_RECORDING_SOURCE, 2))
-                .Returns(true)
+                .Returns(false)
                 .SetDescription("Checks an event type 2 with episode name")
                 .SetName("Test2WithEpisode");
 
             yield return new TestCaseData(new EventLogEntryWrapper("Recording of Futurama: The Sting began as scheduled on 12/11/2013 3:37:58 AM while the program was already in progress.",
                 WMC_RECORDING_SOURCE, 2))
-                .Returns(true)
+                .Returns(false)
                 .SetDescription("Checks an event type 2 with episode name")
                 .SetName("Test2WithEpisode");
 
@@ -83,7 +83,7 @@ namespace WMCDuplicateRemover.Tests.Wrappers
 
             yield return new TestCaseData(new EventLogEntryWrapper("Recording of The Simpsons: Wild Barts Can't Be Broken began as scheduled on 4/13/2015 9:25:01 PM and was manually stopped on 4/13/2015 9:53:38 PM.",
                 WMC_RECORDING_SOURCE, 3))
-                .Returns(true)
+                .Returns(false)
                 .SetDescription("Checks an event type 3 with episode name")
                 .SetName("Test3WithEpisode");
 
@@ -95,7 +95,7 @@ namespace WMCDuplicateRemover.Tests.Wrappers
 
             yield return new TestCaseData(new EventLogEntryWrapper("Forensic Files: Sunday's Wake was manually deleted on 5/27/2015 6:20:41 PM by Corey.", 
                 WMC_RECORDING_SOURCE, 17))
-                .Returns(true)
+                .Returns(false)
                 .SetDescription("Checks an event type 17 with episode name")
                 .SetName("Test17WithEpisode");
 

--- a/WMCDuplicateRemover/Code/Wrappers/EventLogEntryWrapper.cs
+++ b/WMCDuplicateRemover/Code/Wrappers/EventLogEntryWrapper.cs
@@ -7,7 +7,23 @@ namespace WMCDuplicateRemover
     public class EventLogEntryWrapper
     {
         private const string WMC_RECORDING_SOURCE = "Recording";
-        private List<long> ValidInstanceIds = new List<long>() { 1, 2, 3, 17, 24 };
+
+        enum RecordingInstanceType
+        {
+            CompletedSuccessfuly = 1,
+            BeganWhileInProgress = 2,
+            HadSignalLoss = 3,
+            PartialRecordingDueToPowerLossOrTemporaryFailure = 4,
+            NotRecordedDueToConflict = 6,
+            NotRecordedDueToSystemMalfunctionOrPowerLoss = 7,
+            TunerNotWorkingOrInstalled = 8,
+            ManuallyDeleted = 17,
+            ScheduledRecordingRemoved = 21,
+            Cancelled = 24,
+        }
+        
+        //TODO: Make the valid instances configurable, that way the control is left to the user as to which circumstances should count as a success.
+        private List<long> ValidInstanceIds = new List<long>() { (long)RecordingInstanceType.CompletedSuccessfuly, (long)RecordingInstanceType.Cancelled };
         private string Message { get; set; }
         public long InstanceId { get; private set; }
         public string Source { get; private set; }

--- a/WMCDuplicateRemover/Code/Wrappers/MicrosoftEventLogWrapper.cs
+++ b/WMCDuplicateRemover/Code/Wrappers/MicrosoftEventLogWrapper.cs
@@ -10,7 +10,6 @@ namespace WMCDuplicateRemover
         public MicrosoftEventLogWrapper()
         {
             eventLogCache = new HashSet<string>();
-            var eventLogEntries = new List<string>();
 
             var eventLog = new EventLog("Media Center");
 
@@ -20,8 +19,6 @@ namespace WMCDuplicateRemover
                 if (entryWrapper.IsValidRecordingEntry)
                     eventLogCache.Add(CleanRecordingName(entryWrapper.RecordingName));
             }
-
-            eventLogCache.UnionWith(eventLogEntries);
         }
 
         public override bool FoundEventForRecording(string seriesName, string episodeName)


### PR DESCRIPTION
Created an enum to house the instance type numbers that are written to the log so they are more expressive. Removed the UnionWith in the event log wrapper, as it was always unioning an empty list. Made the event id numbers more restrictive for only recordings that were successful or previously cancelled and updated tests accordingly
