### PR TITLE
The event log is now less of a major dependency, that will be supplemented by a file.

### DIFF
--- a/WMCDuplicateRemover.Tests/Serialization/ObjectSerializerTests.cs
+++ b/WMCDuplicateRemover.Tests/Serialization/ObjectSerializerTests.cs
@@ -1,0 +1,56 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using WMCDuplicateRemover.Code.Serialization;
+
+namespace WMCDuplicateRemover.Tests.Serialization
+{
+    [TestFixture]
+    public class ObjectSerializationTests
+    {
+        private string _serializedFilePath = @".\SerializedHashSet";
+
+        [Test]
+        public void TestHashSetStringsSerialization()
+        {
+            var eventLogCache = new HashSet<string>
+            {
+                "American Gothic: The Oxbow",
+                "The Daily Show: June 3, 2016",
+                "Star Talk: Larry Wilmore"
+            };
+
+            var serializer = new ObjectSerializer();
+            serializer.WriteToBinaryFile(_serializedFilePath, eventLogCache);
+            var deserializer = new ObjectDeserializer();
+            var resultingHashSet = deserializer.ReadFromBinaryFile<HashSet<string>>(_serializedFilePath);
+
+            Assert.AreEqual(eventLogCache, resultingHashSet);
+        }
+
+        [Test]
+        public void TestSerializeToNullFile()
+        {
+            var testHashSet = new HashSet<string>();
+            var serializer = new ObjectSerializer();
+            Assert.Throws<ArgumentNullException>(() => serializer.WriteToBinaryFile(null, testHashSet));
+        }
+
+        [Test]
+        public void TestDeserializeWithNullFilePath()
+        {
+            var testHashSet = new HashSet<string>();
+            var deserializer = new ObjectDeserializer();
+            Assert.AreEqual(new HashSet<string>(), deserializer.ReadFromBinaryFile<HashSet<string>>(null));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            File.Delete(_serializedFilePath);
+        }
+    }
+}

--- a/WMCDuplicateRemover.Tests/WMCDuplicateRemover.Tests.csproj
+++ b/WMCDuplicateRemover.Tests/WMCDuplicateRemover.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ScheduledEventWrapper\ScheduledEventCancellationIntegrationTests.cs" />
     <Compile Include="ScheduledEventWrapper\ScheduledEventTestsCanEventBeCancelledTests.cs" />
     <Compile Include="ScheduledEventWrapper\ScheduledEventTestScheduledEventToStringTests.cs" />
+    <Compile Include="Serialization\ObjectSerializerTests.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="ScheduledEventWrapper\MockScheduledEvent.cs" />
     <Compile Include="ScheduledEventWrapper\ScheduledEventTests.cs" />

--- a/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperTestCases.cs
+++ b/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperTestCases.cs
@@ -6,7 +6,7 @@ namespace WMCDuplicateRemover.Tests.Wrappers
 {
     public class EventLogEntryWrapperRecordingNameTestCases : TestData
     {
-        private const String WMC_RECORDING_SOURCE = "Recording";
+        private const string WMC_RECORDING_SOURCE = "Recording";
         protected override IEnumerable CreateTestData()
         {
             yield return new TestCaseData(new EventLogEntryWrapper(

--- a/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperTests.cs
+++ b/WMCDuplicateRemover.Tests/Wrappers/EventLogEntryWrapperTests.cs
@@ -1,19 +1,12 @@
 ﻿using NUnit.Framework;
-using System;
 
 namespace WMCDuplicateRemover.Tests.Wrappers
 {
     [TestFixture]
     public class EventLogEntryWrapperTests
     {
-        [TestFixtureSetUp]
-        public void SetUp()
-        {
-
-        }
-
         [TestCaseSource(typeof(EventLogEntryWrapperRecordingNameTestCases))]
-        public String TestGetRecordingNameFromEventLogEntry(EventLogEntryWrapper eventLogEntry)
+        public string TestGetRecordingNameFromEventLogEntry(EventLogEntryWrapper eventLogEntry)
         {
             return eventLogEntry.RecordingName;
         }

--- a/WMCDuplicateRemover/Code/Serialization/ObjectDeserializer.cs
+++ b/WMCDuplicateRemover/Code/Serialization/ObjectDeserializer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+
+namespace WMCDuplicateRemover.Code.Serialization
+{
+    public class ObjectDeserializer
+    {
+        public T ReadFromBinaryFile<T>(string filePath)
+        {
+            try
+            {
+                using (var stream = File.Open(filePath, FileMode.Open))
+                {
+                    var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                    return (T)binaryFormatter.Deserialize(stream);
+                }
+            }
+            catch
+            {
+                return (T)Activator.CreateInstance(typeof(T));
+            }
+        }
+    }
+}

--- a/WMCDuplicateRemover/Code/Serialization/ObjectSerializer.cs
+++ b/WMCDuplicateRemover/Code/Serialization/ObjectSerializer.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+
+namespace WMCDuplicateRemover.Code.Serialization
+{
+    public class ObjectSerializer
+    {
+        public void WriteToBinaryFile<T>(string filePath, T objectToWrite, bool append = false)
+        {
+            using (var stream = File.Open(filePath, append ? FileMode.Append : FileMode.Create))
+            {
+                var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                binaryFormatter.Serialize(stream, objectToWrite);
+            }
+        }
+    }
+}

--- a/WMCDuplicateRemover/WMCDuplicateRemover.csproj
+++ b/WMCDuplicateRemover/WMCDuplicateRemover.csproj
@@ -59,6 +59,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Code\EPG\Episode.cs" />
+    <Compile Include="Code\Serialization\ObjectDeserializer.cs" />
+    <Compile Include="Code\Serialization\ObjectSerializer.cs" />
     <Compile Include="Code\Wrappers\DateTimeWrapper.cs" />
     <Compile Include="Code\Wrappers\EpgWrapper.cs" />
     <Compile Include="Code\Wrappers\IDateTime.cs" />


### PR DESCRIPTION
Added classes and tests for serializing and deserializing objects. The event log is now supplemented by a file that gets created every time the program runs. That way if the event log gets too large and starts expiring recordings the persistent cache will still be there
