### PR TITLE
Issue #28

### DIFF
--- a/WMCDuplicateRemover.Tests/EPG/TVEpisodeTestCases.cs
+++ b/WMCDuplicateRemover.Tests/EPG/TVEpisodeTestCases.cs
@@ -23,6 +23,36 @@ namespace WMCDuplicateRemover.Tests.EPG
                 .SetDescription("Checks 9PM Showing of forensic files")
                 .SetName("TestGetForensicFilesEpisode");
 
+            yield return new TestCaseData(new DateTime(2015, 5, 5, 18, 0, 0), new DateTime(2015, 5, 5, 19, 0, 0), new DateTime(2014, 5, 07), 7)
+                .Returns(new Episode()
+                {
+                    ChannelId = "I7.28455196.microsoft.com",
+                    StartString = "20150505180000 -0500",
+                    EndString = "20150505190000 -0500",
+                    SeriesName = "Criminal Minds",
+                    EpisodeName = "Angels",
+                    Description = "When prostitutes are murdered in Texas, their deaths seem to have religious overtones; members of the team are put at risk throughout the course of the investigation.",
+                    OriginalAirDateString = "20140507",
+                    EpisodeParts = new[] { new Episode.EpisodeNumber { Name = "xmltv_ns", Value = "..0/2" } }
+                })
+                .SetDescription("Checks 7PM Showing of criminal minds part 1")
+                .SetName("TestGetCriminalMindsPart1Episode");
+
+            yield return new TestCaseData(new DateTime(2015, 5, 5, 19, 0, 0), new DateTime(2015, 5, 5, 20, 0, 0), new DateTime(2014, 5, 14), 7)
+                .Returns(new Episode()
+                {
+                    ChannelId = "I7.28455196.microsoft.com",
+                    StartString = "20150505190000 -0500",
+                    EndString = "20150505200000 -0500",
+                    SeriesName = "Criminal Minds",
+                    EpisodeName = "Demons",
+                    Description = "The investigation in Texas reveals a deep web of corruption; Garcia must save a friend.",
+                    OriginalAirDateString = "20140514",
+                    EpisodeParts = new[] { new Episode.EpisodeNumber { Name = "xmltv_ns", Value = "..1/2" } }
+                })
+                .SetDescription("Checks 7PM Showing of criminal minds part 2")
+                .SetName("TestGetCriminalMindsPart2Episode");
+
             yield return new TestCaseData(new DateTime(2015, 4, 29, 22, 0, 0), new DateTime(2015, 4, 29, 22, 31, 0), new DateTime(2015, 04, 29), 659)
                 .Returns(new Episode()
                 {

--- a/WMCDuplicateRemover.Tests/ScheduledEventWrapper/ScheduledEventTests.cs
+++ b/WMCDuplicateRemover.Tests/ScheduledEventWrapper/ScheduledEventTests.cs
@@ -41,7 +41,7 @@ namespace WMCDuplicateRemover.Tests.ScheduledEventWrapper
                 OriginalAirDateString = testData.ScheduledEvent.OriginalAirDate.ToString("yyyyMMddHHmmss")
             };
             var eventLogWrapper = new Mock<EventLogWrapper>();
-            eventLogWrapper.Setup(x => x.FoundEventForRecording(It.IsAny<string>(), It.IsAny<string>())).Returns(testData.EventLogFoundEventForRecordingResponse);
+            eventLogWrapper.Setup(x => x.FoundEventForRecording(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(testData.EventLogFoundEventForRecordingResponse);
             Assert.AreEqual(testData.ExpectedResult, testData.ScheduledEvent.CanEventBeCancelled(eventLogWrapper.Object, episode));
         }
 

--- a/WMCDuplicateRemover.Tests/WMCDuplicateRemover.Tests.csproj
+++ b/WMCDuplicateRemover.Tests/WMCDuplicateRemover.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props" Condition="Exists('..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -94,6 +97,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnitTestAdapter.2.3.0\build\NUnitTestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WMCDuplicateRemover.Tests/packages.config
+++ b/WMCDuplicateRemover.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
   <package id="Moq" version="4.5.13" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="NUnitTestAdapter" version="2.3.0" targetFramework="net461" />
 </packages>

--- a/WMCDuplicateRemover/Code/Wrappers/EventLogWrapper.cs
+++ b/WMCDuplicateRemover/Code/Wrappers/EventLogWrapper.cs
@@ -2,6 +2,6 @@
 {
     public abstract class EventLogWrapper
     {
-        public abstract bool FoundEventForRecording(string seriesName, string episodeName);
+        public abstract bool FoundEventForRecording(string seriesName, string episodeName, string episodePart);
     }
 }

--- a/WMCDuplicateRemover/Code/Wrappers/ScheduledEvent.cs
+++ b/WMCDuplicateRemover/Code/Wrappers/ScheduledEvent.cs
@@ -35,7 +35,7 @@ namespace WMCDuplicateRemover
 
         private bool EventLogInformationAllowsForCancellation(EventLogWrapper entryWrapper, Episode episode)
         {
-            return entryWrapper.FoundEventForRecording(episode.SeriesName, episode.EpisodeName);
+            return entryWrapper.FoundEventForRecording(episode.SeriesName, episode.EpisodeName, episode.EpisodePart);
         }
 
         public override string ToString()

--- a/WMCDuplicateRemoverDriver/Program.cs
+++ b/WMCDuplicateRemoverDriver/Program.cs
@@ -4,7 +4,8 @@
     {
         static void Main(string[] args)
         {
-            var driver = new Driver();
+            var dryRun = args.Length > 0 && args[0] == "--dryrun";
+            var driver = new Driver(dryRun);
             driver.Run();
         }
     }

--- a/WMCDuplicateRemoverDriver/WMCDuplicateRemoverDriver.csproj
+++ b/WMCDuplicateRemoverDriver/WMCDuplicateRemoverDriver.csproj
@@ -19,6 +19,9 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
* Added fields to the xml to pick up the episode-num data from the epg xml
* Added a debug text file for the event log cache to easily see what's
in the event log
* Utilized the new EpisodePart field to match to the event log recording
name
* Added tests that cover the logic in the EpisodePart getter
* Added the NUnit test adapter to run tests within VS
* Added a dry run flag for testing that will log cancellations without
actually sending the cancel signal to WMC